### PR TITLE
gitlab-runners workers instance types as a variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,17 @@ tf/apply/audit:
 tf/apply/gitlab-permissions:
 	cd live/${ENV}/gitlab-permissions && terragrunt run-all --terragrunt-non-interactive apply -auto-approve
 
+tf/init/gitlab-runners:
+	cd live/${ENV}/gitlab-runners && terragrunt run-all --terragrunt-non-interactive init
+
+tf/plan/gitlab-runners:
+	cd live/${ENV}/gitlab-runners && terragrunt run-all --terragrunt-non-interactive plan
+
 tf/apply/gitlab-runners:
 	cd live/${ENV}/gitlab-runners && terragrunt run-all --terragrunt-non-interactive apply -auto-approve
+
+tf/destroy/gitlab-runners:
+	cd live/${ENV}/gitlab-runners && terragrunt run-all --terragrunt-non-interactive destroy
 
 tf/apply/oidc:
 	cd live/${ENV}/oidc && terragrunt run-all --terragrunt-non-interactive apply -auto-approve

--- a/modules/gitlab-runners/main.tf
+++ b/modules/gitlab-runners/main.tf
@@ -70,7 +70,7 @@ module "runner-instance-1" {
   }
 
   runner_worker_cache = {
-    bucket_prefix = "1-"
+    bucket_prefix = "1"
     create        = "true"
     versioning    = "true"
     shared        = "true"
@@ -132,7 +132,7 @@ module "runner-instance-1" {
   }
 
   runner_worker_docker_machine_instance = {
-    types = ["t3.micro"]
+    types = var.docker-machine-types
   }
 
   runner_networking = {
@@ -167,7 +167,7 @@ module "runner-instance-2" {
   }
 
   runner_worker_cache = {
-    bucket_prefix = "2-"
+    bucket_prefix = "2"
     create        = "true"
     versioning    = "true"
     shared        = "true"
@@ -229,7 +229,7 @@ module "runner-instance-2" {
   }
 
   runner_worker_docker_machine_instance = {
-    types = ["t3.micro"]
+    types = var.docker-machine-types
   }
 
   runner_networking = {
@@ -241,6 +241,6 @@ module "runner-instance-2" {
   runner_role = {
     role_profile_name = "runner-2"
   }
-  iam_object_prefix                        = "2-"
+  iam_object_prefix                        = "2"
   runner_terminate_ec2_lifecycle_hook_name = "terminate-instances-2"
 }

--- a/modules/gitlab-runners/variables.tf
+++ b/modules/gitlab-runners/variables.tf
@@ -70,3 +70,9 @@ variable "user" {
   description = "User name"
   type        = string
 }
+
+variable "docker-machine-types" {
+  description = "Gitlab runner docker machine type"
+  type        = list(string)
+  default     = ["t3.micro"]
+}


### PR DESCRIPTION
Runner worker docker machine instance types as a variable such that the default can be overridden by a variable defined in tfvars file